### PR TITLE
Compilation error fix for Eclipse 4.7 (Oxygen).

### DIFF
--- a/src/org/eclipse/jdt/luna/formatter/CodeFormatterVisitor.java
+++ b/src/org/eclipse/jdt/luna/formatter/CodeFormatterVisitor.java
@@ -1862,7 +1862,7 @@ public class CodeFormatterVisitor extends ASTVisitor {
 			boolean spaceAfterSemicolon,
 			int tryResourcesAligment) {
 
-		LocalDeclaration[] resources = tryStatement.resources;
+		Statement[] resources = tryStatement.resources;
 		int length = resources != null ? resources.length : 0;
 		if (length > 0) {
 			this.scribe.printNextToken(TerminalTokens.TokenNameLPAREN, spaceBeforeOpenParen);


### PR DESCRIPTION
Fixes a compilation error when building the plugin against Eclipse 4.7
(Oxygen).

Frankly, I have no idea if this breaks something or not, but this is how I got it working on Oxygen. I've only used it for like half a day for now, but this far it seems to be working. Anyway, I'll be needing the old formatter implementation for sure, so probably I'll try to fix it if this change turns out to break something.