### PR TITLE
Build settings and rebuild to address 2019-06

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,12 +1,12 @@
 Manifest-Version: 1.0
 Bundle-SymbolicName: OldJavaFormatter;singleton:=true
 Bundle-Name: OldJavaFormatter
-Bundle-Version: 1.3.1
+Bundle-Version: 1.4.0
 Require-Bundle: org.eclipse.jdt.core;bundle-version="[3.17.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.15.0,4.0.0)",
- org.eclipse.core.runtime
+ org.eclipse.core.runtime;bundle-version="[3.15.0,4.0.0)"
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8,
- JavaSE-9
+ JavaSE-11
 Automatic-Module-Name: OldJavaFormatter
 

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-SymbolicName: OldJavaFormatter;singleton:=true
 Bundle-Name: OldJavaFormatter
-Bundle-Version: 1.4.0
+Bundle-Version: 1.4.1
 Require-Bundle: org.eclipse.jdt.core;bundle-version="[3.17.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.15.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.15.0,4.0.0)"

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ Original plugin can be found [here](http://eclipse-n-mati.blogspot.com.es/2015/0
 * For Eclipse Mars (4.5) to 2018-09: Please use version 1.1.5 of this plugin.
 * For Eclipse 2018-12: Please use version 1.2.0 of this plugin.
 * For Eclipse 2019-03: Please use version 1.3.1 of this plugin.
+* For Eclipse 2019-06: Please use version 1.4.0 of this plugin.
+    * The 1.4.0 version contains no code changes; it contains build setting changes and was built using Eclipse 2019-06.
+    * Before upgrading to this version, consider backing up your formatter settings (via Export).
+    * If, after upgrading eclipse to 2019-06 and this plugin to 1.4.0, the formatter does not work, there is a fix; there seems to be an occassional issue when upgrading that is fixed with the following steps:
+        1. Change to the default Eclipse formatter.
+        2. Change back to the `Old Luna Java Formatter`.
+        3. Re-import your saved settings (select overwrite if prompted).

--- a/README.md
+++ b/README.md
@@ -23,10 +23,5 @@ Original plugin can be found [here](http://eclipse-n-mati.blogspot.com.es/2015/0
 * For Eclipse Mars (4.5) to 2018-09: Please use version 1.1.5 of this plugin.
 * For Eclipse 2018-12: Please use version 1.2.0 of this plugin.
 * For Eclipse 2019-03: Please use version 1.3.1 of this plugin.
-* For Eclipse 2019-06: Please use version 1.4.0 of this plugin.
-    * The 1.4.0 version contains no code changes; it contains build setting changes and was built using Eclipse 2019-06.
-    * Before upgrading to this version, consider backing up your formatter settings (via Export).
-    * If, after upgrading eclipse to 2019-06 and this plugin to 1.4.0, the formatter does not work, there is a fix; there seems to be an occassional issue when upgrading that is fixed with the following steps:
-        1. Change to the default Eclipse formatter.
-        2. Change back to the `Old Luna Java Formatter`.
-        3. Re-import your saved settings (select overwrite if prompted).
+* For Eclipse 2019-06: Please use version 1.4.1 of this plugin.
+    * Please note that this may not work well with the new arrow based switch statements (if at all).

--- a/src/org/eclipse/jdt/luna/formatter/CodeFormatterVisitor.java
+++ b/src/org/eclipse/jdt/luna/formatter/CodeFormatterVisitor.java
@@ -914,6 +914,8 @@ public class CodeFormatterVisitor extends ASTVisitor {
 		try {
 			compilationUnitDeclaration.traverse(this, compilationUnitDeclaration.scope);
 		} catch(AbortFormatting e){
+			if (DEBUG)
+				e.printStackTrace(System.out);
 			return failedToFormat();
 		}
 		if (DEBUG){
@@ -2117,7 +2119,7 @@ public class CodeFormatterVisitor extends ASTVisitor {
 				this.scribe.printNewLine();
 			}
 			statement.traverse(this, scope);
-			if (statement instanceof Expression) {
+			if (statement instanceof Expression && !(statement instanceof SwitchStatement)) {
 				this.scribe.printNextToken(TerminalTokens.TokenNameSEMICOLON, this.preferences.insert_space_before_semicolon);
 				this.scribe.printComment(CodeFormatter.K_UNKNOWN, Scribe.BASIC_TRAILING_COMMENT);
 				if (i != statementsLength - 1) {


### PR DESCRIPTION
 - Removed deprecated Java 9 as a version dependency; changed to Java 11.
 - Added guardrails around runtime dependency.
 - Increased version to 1.4.0 to make it easy to identify for those looking for a 2019-06 compatible version.
 - Updated README.