### PR TITLE
2019-12 compatibility

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-SymbolicName: OldJavaFormatter;singleton:=true
 Bundle-Name: OldJavaFormatter
-Bundle-Version: 1.4.1
+Bundle-Version: 1.5.0
 Require-Bundle: org.eclipse.jdt.core;bundle-version="[3.17.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.15.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.15.0,4.0.0)"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Original plugin can be found [here](http://eclipse-n-mati.blogspot.com.es/2015/0
 * For Eclipse 2019-03: Please use version 1.3.1 of this plugin.
 * For Eclipse 2019-06: Please use version 1.4.1 of this plugin.
     * Please note that this may not work well with the new arrow based switch statements (if at all).
+* For Eclipse 2019-12: Please use version 1.5.0 of this plugin.

--- a/src/org/eclipse/jdt/luna/formatter/DefaultCodeFormatter.java
+++ b/src/org/eclipse/jdt/luna/formatter/DefaultCodeFormatter.java
@@ -409,7 +409,7 @@ public class DefaultCodeFormatter extends CodeFormatter {
 		if (PROBING_SCANNER == null) {
 			// scanner use to check if the kind could be K_JAVA_DOC, K_MULTI_LINE_COMMENT or K_SINGLE_LINE_COMMENT
 			// do not tokenize white spaces to get single comments even with spaces before...
-			PROBING_SCANNER = new Scanner(true, false/*do not tokenize whitespaces*/, false/*nls*/, ClassFileConstants.JDK1_6, ClassFileConstants.JDK1_6, null/*taskTags*/, null/*taskPriorities*/, true/*taskCaseSensitive*/);
+			PROBING_SCANNER = new Scanner(true, false/*do not tokenize whitespaces*/, false/*nls*/, ClassFileConstants.JDK1_6, ClassFileConstants.JDK1_6, null/*taskTags*/, null/*taskPriorities*/, true/*taskCaseSensitive*/, false/*isPreviewEnabled*/ );
 		}
 		PROBING_SCANNER.setSource(source.toCharArray());
 


### PR DESCRIPTION
Fixing compatibility issues with Eclipse 19-12 (maybe already in 19-09, see issue https://github.com/alostale/luna-java-formatter/issues/14 ?) 

Fixed runtime error is:
```
java.lang.NoSuchMethodError: org.eclipse.jdt.internal.compiler.parser.Scanner.<init>(ZZZJJ[[C[[CZ)V
	at org.eclipse.jdt.luna.formatter.DefaultCodeFormatter.probeFormatting(DefaultCodeFormatter.java:412)
	at org.eclipse.jdt.luna.formatter.DefaultCodeFormatter.format(DefaultCodeFormatter.java:173)
	at org.eclipse.jdt.luna.formatter.DefaultCodeFormatter.format(DefaultCodeFormatter.java:150)
	at org.eclipse.jdt.internal.corext.util.CodeFormatterUtil.format2(CodeFormatterUtil.java:230)
	at org.eclipse.jdt.internal.corext.util.CodeFormatterUtil.format2(CodeFormatterUtil.java:257)
	at org.eclipse.jdt.internal.corext.template.java.JavaFormatter.format(JavaFormatter.java:356)
	at org.eclipse.jdt.internal.corext.template.java.JavaFormatter.internalFormat(JavaFormatter.java:289)
	at org.eclipse.jdt.internal.corext.template.java.JavaFormatter.format(JavaFormatter.java:269)
	at org.eclipse.jdt.internal.corext.template.java.JavaContext.evaluate(JavaContext.java:114)
	at org.eclipse.jdt.internal.ui.text.template.contentassist.TemplateProposal.getAdditionalProposalInfo(TemplateProposal.java:455)
	at org.eclipse.jface.text.contentassist.AdditionalInfoController$Timer$4.lambda$0(AdditionalInfoController.java:183)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
..
```

which occurred when trying to apply a code template using content assist.
