### PR TITLE
API Update Fixes for 1.10.X

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-SymbolicName: OldJavaFormatter;singleton:=true
 Bundle-Name: OldJavaFormatter
-Bundle-Version: 1.10.0
+Bundle-Version: 1.10.1
 Require-Bundle: org.eclipse.jdt.core;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.18.100,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.23.0,4.0.0)"

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Original plugin can be found [here](http://eclipse-n-mati.blogspot.com.es/2015/0
 | 1.7.0   | 2020-09                      | Luna, Neon | No code changes, but rather a rebuild with the 2020-09 toolchain. |
 | 1.8.0   | 2020-12, 2021-03             | Luna, Neon | No code changes, but rather a rebuild with the 2020-12 toolchain. |
 | 1.9.0   | 2021-06                      | Luna, Neon | Changed library dependency versions, rebuild of plugin with 2021-06 toolchain. |
-| 1.10.0  | 2021-09                      | Luna, Neon | Changed library dependency versions, addressed compiler warnings, addressed deprecated API warnings, addressed breaks caused by upstream API changes. |
+| 1.10.1  | 2021-09                      | Luna, Neon | Changed library dependency versions, addressed compiler warnings, addressed deprecated API warnings, addressed breaks caused by upstream API changes. |

--- a/src/org/eclipse/jdt/luna/formatter/CodeFormatterVisitor.java
+++ b/src/org/eclipse/jdt/luna/formatter/CodeFormatterVisitor.java
@@ -3289,10 +3289,9 @@ public class CodeFormatterVisitor extends ASTVisitor {
 			this.scribe.printNextToken(TerminalTokens.TokenNamedefault);
 			this.scribe.printNextToken(TerminalTokens.TokenNameCOLON, this.preferences.insert_space_before_colon_in_default);
 		} else {
-			this.scribe.printNextToken(TerminalTokens.TokenNamecase);
-			this.scribe.space();
-
 			for (int i = 0; i < cexpr.length; ++i) {
+                this.scribe.printNextToken(TerminalTokens.TokenNamecase);
+                this.scribe.space();
 			    cexpr[i].traverse(this, scope);
 			    this.scribe.printNextToken(TerminalTokens.TokenNameCOLON, this.preferences.insert_space_before_colon_in_case);
 			}

--- a/src/org/eclipse/jdt/neon/formatter/SpacePreparator.java
+++ b/src/org/eclipse/jdt/neon/formatter/SpacePreparator.java
@@ -366,11 +366,12 @@ public class SpacePreparator extends ASTVisitor {
         if (node.isDefault()) {
             handleToken(node, TokenNameCOLON, this.options.insert_space_before_colon_in_default, false);
         } else {
-            handleToken(node, TokenNamecase, false, true);
-
             // Null check not required as we checked isDefault() above.
             final List<Expression> expressions = node.expressions();
-            expressions.forEach((x) -> handleToken(x, TokenNameCOLON, this.options.insert_space_before_colon_in_case, false));
+            expressions.forEach((x) -> {
+                handleToken(node, TokenNamecase, false, true);
+                handleToken(x, TokenNameCOLON, this.options.insert_space_before_colon_in_case, false);
+            });
         }
         return true;
     }


### PR DESCRIPTION
The code worked as it was, but it is not technically correct (it worked by nature of how the formatter works that ensured arrays/lists would always be size 1). This fix corrects the incorrect implementation.